### PR TITLE
release version 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ objectel is library which provides highly-abstracted object in order to resolve 
 
 objectel uses few un-popular mindset which is called [callbag](https://github.com/callbag/callbag)
 I just told you "callbag is unpopular mindset". but don't think callbag badly, it is awesome standard.
-if you overcome some complexity of callbag, then you may find yourself in 'callbag haven'.
+if you overcome some complexity of callbag, then you may find yourself in 'callbag heaven'.
 
 here is some good articles about callbag, if you doesn't friendly with callbag, you will do better to read these articles.
 
@@ -29,7 +29,7 @@ this article does not related to callbag, but I believe this is one of best arti
 every complex problem could be split into several less-complex problem(also known as divide and conquer).
 objectel suggest to use component at dividing problem.
 
-anyway, in viewpoint of library, every component is a function that takes `props` and returns a function which input is stream(callbag) of event and output is stream of result.
+anyway, in viewpoint of library, every component is a function that takes `props` and returns a function which takes stream(callbag) of event and returns listenable callbag of result(also known as **element**).
 
 also, instant of component is called **element**
 #### Ol.createElement(type, props, children)
@@ -54,16 +54,15 @@ forEach(console.log)(Ol.createElement('a', { herf: 'somewhere' }, 'go!'))
 // logs { type: 'a', { herf: 'somewhere', children: 'go!' } }
 ```
 
-#### Ol.createElement(component, props, children, [event$])
+#### Ol.createElement(component, props, ...children)
 
 | Arguments | Description |
 |-----------|-------------|
 | component | a component |
 | props | a object or `null`, will be applied to component when `createElement` creates instance of component. |
 | children | any value, will be settled to `props.children`. |
-| event$ | listenable that produces event, used as source of component. if `event$` is omitted, `props.event$` will be replaced `event$`'s place. |
 
-* returns stream of results
+* returns a function which takes stream of event and returns stream of results
 
 `createElement` is function that creates element of given component.
 
@@ -110,29 +109,6 @@ const Counter = Ol.reactiveComponent(
   Ol.operators.reduce(prevModel => prevModel + 1, 0),
   map(model => Ol.createElement('text', null, model)),
 );
-```
-
-#### Ol.reactiveComponent(componentFactory)
-
-| Arguments | Description |
-|-----------|-------------|
-| componentFactory | takes `props` as argument, returns a function which takes stream of event as argument and returns stream of results |
-
-* returns newly created component
-
-Examples
-
-Simple Counter Component with prop binding
-
-```js
-import * as Ol from 'objectel';
-import map from 'callbag-map';
-
-const Counter = Ol.reactiveComponent(({ count, startValue}) => compose(
-  Ol.operators.ofType('increase'),
-  Ol.operators.reduce(prevModel => prevModel + count, startValue),
-  map(model => Ol.createElement('text', null, model)),
-));
 ```
 
 #### Ol.component(propsToModel, modelToResult, [eventMap])
@@ -248,7 +224,7 @@ Simple Event
 ```js
 import * as Ol from 'objectel';
 
-const myEvent = Ol.Event('increase', 10, { by: 'click' });
+const myEvent = Ol.createEvent('increase', 10, { by: 'click' });
 // { type: 'increase', payload: 10, meta: { by: 'click' } };
 ```
 
@@ -269,7 +245,7 @@ import * as Ol from 'objectel';
 import Counter from './counter';// let's say we have a counter
 
 const globalBus = Ol.createEventBus(Ol.createEvent('increase'));
-const counter = Ol.createElement(Counter, globalBus.Listener$);
+const counter = Ol.createElement(Counter)(globalBus.Listen$);
 ```
 
 #### EventBus.Listen$
@@ -295,4 +271,4 @@ filters stream of event
 If you are trying to use Ol, you don't need to read this part.
 this part describes interface of `Element` in Ol.
 
-Each `Element` is pullable which takes event and produces result.
+Each `Element` is a function which takes stream of event and returns listenable which produces result.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,6 +1439,11 @@
         "unset-value": "^1.0.0"
       }
     },
+    "callbag-flatten": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/callbag-flatten/-/callbag-flatten-1.2.0.tgz",
+      "integrity": "sha512-R3W/2HgYxHd5JbKpFbJggg8kAJKjkh2DynLRIFVQ8XD23pku+eYe/XjTV6ezysGvVoyDi96sQlRiI82yJqYGSA=="
+    },
     "callbag-map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/callbag-map/-/callbag-map-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "objectel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "rollup-plugin-node-resolve": "^4.0.0"
   },
   "dependencies": {
+    "callbag-flatten": "^1.2.0",
     "callbag-map": "^1.0.1",
     "callbag-merge": "^3.1.0",
     "callbag-pipe": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "provides api to manipulate highly-abstracted object in order to resolve hierarchical problem via composition",
   "index": "index.js",
   "main": "build/lib/objectel.js",

--- a/src/createElement.js
+++ b/src/createElement.js
@@ -1,25 +1,27 @@
-import { voidSource, once } from './utils';
-import pipe from 'callbag-pipe';
+import { once } from './utils';
 
 function createStructuralElement(type, props, children) {
-  return once({
+  return () => once({
     type,
     props: { ...props, children },
   });
 }
 
+function createReactiveElement(component, props, children) {
+  const componentFactory = component(props);
+  if (props === null) props = {};
+  props.children = children;
+
+  return componentFactory;
+}
+
 export default function createElement(
   component,
   props,
-  children,
-  event$ = props && props.event$ || voidSource
+  ...children
 ) {
-  if (typeof component !== 'function') return createStructuralElement(component, props, children);
-  if (props === null) props = {};
-  props.event$ = event$;
-  props.children = children;
-  return pipe(
-    event$,
-    component(props),
-  );
+  return typeof component !== 'function' ?
+    createStructuralElement(component, props, children)
+    :
+    createReactiveElement(component, props, children);
 }

--- a/src/operators/flatMap.js
+++ b/src/operators/flatMap.js
@@ -1,0 +1,5 @@
+import { compose } from '../utils';
+import map from 'callbag-map';
+import flatten from 'callbag-flatten';
+
+export default compose(flatten, map);

--- a/src/operators/index.js
+++ b/src/operators/index.js
@@ -1,7 +1,9 @@
 import ofType from './ofType';
 import reduce from './reduce';
+import flatMap from './flatMap';
 
 export default {
   ofType,
-  reduce
+  reduce,
+  flatMap,
 };

--- a/src/reactiveComponent.js
+++ b/src/reactiveComponent.js
@@ -1,18 +1,7 @@
 import { compose } from './utils';
 
-function reactiveComponentWithFactory(componentFactory) {
-  return componentFactory;
-}
-
-function reactiveComponentWithoutFactory(intent$, model$, result$) {
+export default function reactiveComponent(intent$, model$, result$) {
   const component = compose(result$, model$, intent$);
 
   return () => component;
-}
-
-export default function reactiveComponent(...args) {
-  return args.length === 1 ?
-    reactiveComponentWithFactory(...args)
-    :
-    reactiveComponentWithoutFactory(...args);
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,2 @@
-export { default as voidSource } from './voidSource';
 export { default as compose } from './compose';
 export { default as once } from './once';

--- a/src/utils/voidSource.js
+++ b/src/utils/voidSource.js
@@ -1,5 +1,0 @@
-export default function voidSource(start, sink) {
-  if (start !== 0) return;
-
-  sink(0, () => {});
-}


### PR DESCRIPTION
Changelog

* `reactiveComponent(componentFactory)` has been removed (we already have Functional Component for same purpose).
* `createElement`'s interface(call signature) has been changed to 'createElement(component, props, ...children): element`
* now objectel doesn't provide `voidSource` as default event source for Element.
* `flatMap` operator is added. simply, it's `flatten . map`
